### PR TITLE
fix: Ensure Description and Location fields always exist in event data

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,8 +29,8 @@ type Event struct {
 	Title       string `json:"title"`
 	Start       string `json:"start"`
 	End         string `json:"end"`
-	Description string `json:"description,omitempty"`
-	Location    string `json:"location,omitempty"`
+	Description string `json:"description"`
+	Location    string `json:"location"`
 }
 
 // eventCache は Google Calendar API の結果をキャッシュします。
@@ -46,6 +46,14 @@ func transformEvent(item *calendar.Event) Event {
 	end := item.End.DateTime
 	if end == "" {
 		end = item.End.Date
+	}
+	description := item.Description
+	if description == "" {
+		description = ""
+	}
+	location := item.Location
+	if location == "" {
+		location = ""
 	}
 	return Event{
 		Title:       item.Summary,

--- a/main_test.go
+++ b/main_test.go
@@ -57,6 +57,20 @@ func TestTransformEvent(t *testing.T) {
 	if res2.Location != "" {
 		t.Errorf("Expected empty location, got '%s'", res2.Location)
 	}
+
+	// すべての項目が空でも正しく動作することを確認
+	ev3 := &calendar.Event{
+		Summary:  "Empty Fields Event",
+		Start:    &calendar.EventDateTime{DateTime: "2023-03-01T09:00:00Z"},
+		End:      &calendar.EventDateTime{DateTime: "2023-03-01T10:00:00Z"},
+	}
+	res3 := transformEvent(ev3)
+	if res3.Description != "" {
+		t.Errorf("Expected empty description, got '%s'", res3.Description)
+	}
+	if res3.Location != "" {
+		t.Errorf("Expected empty location, got '%s'", res3.Location)
+	}
 }
 
 func TestErrorResponse(t *testing.T) {


### PR DESCRIPTION
- Removed `omitempty` from `description` and `location` in `Event` struct
- Modified `transformEvent` to set empty strings for `description` and `location` if nil
- Added test case to verify empty fields are handled correctly

This change ensures that Grafana's Business Calendar Plugin receives a consistent event schema, avoiding rendering issues caused by missing fields.

This commit addresses a bug introduced in [#1](https://github.com/watahari/GCalJSON/pull/1), where `description` and `location` were conditionally omitted, leading to unexpected behavior in Grafana.